### PR TITLE
Add peer connection filtering

### DIFF
--- a/MultipeerKit_iOS/MultipeerKit_iOS/Source/Common/MCTransceiver.h
+++ b/MultipeerKit_iOS/MultipeerKit_iOS/Source/Common/MCTransceiver.h
@@ -37,6 +37,8 @@ NSString *NSStringFromMCTransceiverMode(MCTransceiverMode mode);
 -(void)didStopAdvertising;
 -(void)didStartBrowsing;
 -(void)didStopBrowsing;
+-(BOOL)connectWithPeer:(MCPeerID *)peerId;
+-(void)didSkipConnectWithPeer:(MCPeerID *)peerId;
 @end
 
 


### PR DESCRIPTION
This commit has the intent of filtering which peer we should or
shouldn’t establish a connection with. We provide the connectWithPeer:
method, which when implemented, as part of the delegate advises whether
or not to try to establish a connection. In case we determine it is not
a valid peer to connect to, the didSkipConnecWithtPeer: method gets
called, if implemented, with the peer that we decided not to connect
to. The functionality is available for both advertising and browsing
modes.